### PR TITLE
Rotriever allow kebab case

### DIFF
--- a/rotriever.toml
+++ b/rotriever.toml
@@ -6,6 +6,7 @@ publish = true
 
 [config]
 registry_index = true
+allow_kebab_case = true
 
 [dependencies]
 React = "github.com/roblox/roact-alignment@^17.3.7"


### PR DESCRIPTION
- Set `allow_kebab_case = true` so we can publish to the rotriever registry